### PR TITLE
Fix extractor behavior when extracting a linked path in an array of paths

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    xml_data_extractor (0.1.0)
+    xml_data_extractor (0.2.0)
       activesupport
       nokogiri
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.2)
+    activesupport (6.0.3.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -19,7 +19,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     rake (12.3.3)

--- a/lib/src/extract/string_value.rb
+++ b/lib/src/extract/string_value.rb
@@ -22,7 +22,7 @@ module Extract
 
       paths.map do |inner|
         if inner.is_a?(String)
-          extract_value(Node.new({ path: inner }, node_path))
+          extract_value(Node.new({ path: inner, link: node[:props][:link] }, node_path))
         else
           StringValue.new(Node.new(inner, node_path), extractor).value
         end

--- a/lib/xml_data_extractor.rb
+++ b/lib/xml_data_extractor.rb
@@ -5,7 +5,7 @@ require_relative "src/extract/value_builder"
 
 class XmlDataExtractor   
   def initialize(config, modifiers = nil)
-    @config = config      
+    @config = config
     @modifiers = modifiers
   end
 
@@ -18,7 +18,7 @@ class XmlDataExtractor
         value = Extract::ValueBuilder.new(Node.new(val), extractor).value
         hash[key] = value if value.present?
       end
-    end      
+    end
   end
 
   private

--- a/spec/complete_example_spec.rb
+++ b/spec/complete_example_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Complete Example" do
   end
 
   let(:yml) do
-    <<~YML      
+    <<~YML
       mappers: 
         genres:     
           default: unknown
@@ -62,7 +62,7 @@ RSpec.describe "Complete Example" do
             character: char_name
     YML
   end
-  let(:structure) { YAML.load(yml).deep_symbolize_keys }
+  let(:structure) { YAML.safe_load(yml).deep_symbolize_keys }
 
   let(:custom_methods) do
     Class.new do

--- a/spec/link_spec.rb
+++ b/spec/link_spec.rb
@@ -1,0 +1,94 @@
+require "yaml"
+require "json"
+
+RSpec.describe "Link" do
+  subject { XmlDataExtractor.new(structure).parse(xml) }
+
+  context "when linked path is in an array of paths" do
+    let(:xml) do
+      <<~XML
+        <Sales>
+          <Sale>
+            <Locator>Y968XB</Locator>
+            <IssueDate>22/07/2019</IssueDate>
+            <Tickets>
+              <Ticket>
+                <Code>10248270</Code>
+                <Exchange>3,7408000</Exchange>
+                <Passengers>
+                  <Passenger>
+                    <Name>FERNANDES/DAVID</Name>
+                    <Kind>ADT</Kind>
+                  </Passenger>
+                </Passengers>
+              </Ticket>
+            </Tickets>
+            <Totals>
+              <Incentive>16,65</Incentive>
+            </Totals>
+          </Sale>
+          <Sale>
+            <Locator>Y968XB</Locator>
+            <IssueDate>22/07/2019</IssueDate>
+            <Tickets>
+              <Ticket>
+                <Code>10248271</Code>
+                <Exchange>3,7408000</Exchange>
+                <Passengers>
+                  <Passenger>
+                    <Name>FERNANDES/LUIZ</Name>
+                    <Kind>ADT</Kind>
+                  </Passenger>
+                </Passengers>
+              </Ticket>
+            </Tickets>
+            <Totals>
+              <Incentive>12,61</Incentive>
+            </Totals>
+          </Sale>
+        </Sales>
+      XML
+    end
+  
+    let(:yml) do
+      <<~YML
+        schemas:
+          bookings:
+            array_of:
+              path: Sales/Sale
+              uniq_by: Locator
+            date: IssueDate
+            document: Locator
+            products:
+              array_of: Tickets/Ticket
+              exchange_rate: Exchange
+              incentive:
+                path: ['../../../../Sales/Sale[Locator="<link>"]/Totals/Incentive', Exchange]
+                link: ../../Locator
+      YML
+    end
+  
+    let(:structure) { YAML.safe_load(yml).deep_symbolize_keys }
+
+    let(:expected_result) do
+      {
+        bookings: [
+          {
+            date: "22/07/2019",
+            document: "Y968XB",
+            products: [
+              {
+                exchange_rate: "3,7408000",
+                incentive: [["16,65", "12,61"], "3,7408000"]
+              }
+            ]
+          }          
+        ]
+      }
+    end
+
+    it "extracts the data of the linked path" do
+      expect(JSON.pretty_generate(subject)).to eq JSON.pretty_generate(expected_result)
+    end
+  end
+end

--- a/xml_data_extractor.gemspec
+++ b/xml_data_extractor.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "xml_data_extractor"
-  spec.version       = "0.1.0"
+  spec.version       = "0.2.0"
   spec.authors       = ["Fernando Almeida"]
   spec.email         = ["fernandoprsbr@gmail.com"]
 


### PR DESCRIPTION
Was missing pass  the link along the new node.