### PR TITLE
Fix closing br tags escaping

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    xml_data_extractor (0.2.0)
+    xml_data_extractor (0.3.0)
       activesupport (~> 6.0)
       nokogiri (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.3)
+    activesupport (6.0.3.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -39,7 +39,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.1)
 
 PLATFORMS
   ruby

--- a/lib/src/extractor.rb
+++ b/lib/src/extractor.rb
@@ -62,7 +62,7 @@ class NodeExtractor
   private
 
   def remove_special_elements(xml)
-    CGI.unescapeHTML(xml).gsub(/<br>|&nbsp;/, { "<br>" => "", "&nbsp;" => " " })
+    CGI.unescapeHTML(xml).gsub(/<br>|<\/br>|&nbsp;/, { "&nbsp;" => " ", "<br>" => "", "</br>" => "" })
   end
 
   attr_reader :xml

--- a/spec/complete_example_spec.rb
+++ b/spec/complete_example_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "Complete Example" do
     <<~XML
       <xml>
         <movies_list>
-          <movie>            
+          <movie>    
+            <policy>Copyright © 2010 by Wily E. &amp; <br>Coyote All rights reserved.|</br></policy>
             <description>The Lord of the Rings: The Fellowship of the Ring</description>
             <total_minutes>209</total_minutes>
             <year>2001</year>

--- a/xml_data_extractor.gemspec
+++ b/xml_data_extractor.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "xml_data_extractor"
-  spec.version       = "0.2.0"
+  spec.version       = "0.3.0"
   spec.authors       = ["Fernando Almeida"]
   spec.email         = ["fernandoprsbr@gmail.com"]
 


### PR DESCRIPTION
Some XMLs have this alien closing `br` inside some text tags, if we don't remove it, Nokogiry gets lost during the parser and the xpath navigation does not work properly from that tag.