### PR TITLE
Add unescape option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xml_data_extractor (0.3.0)
+    xml_data_extractor (0.4.0)
       activesupport (~> 6.0)
       nokogiri (~> 1.0)
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,42 @@ schemas:
 { movie: { title: "The Irishman", actor: "Robert De Niro" } }
 ```
 
+#### unscape
+
+This option is pretty usefull when you have embbed XML or HTML inside some tag, like CDATA elements, and you need to unescape them first in order to parse their content:
+
+```yml
+schemas:  
+  movie:
+    unescape: response
+    title: response/original_title
+    actor: response/main_actor
+
+```
+
+```xml
+<xml>
+  <response>
+    &ltoriginal_title&gt1&ltoriginal_title&gt&ltmain_actor&gt1&ltmain_actor&gt
+  </response>
+</xml>
+```
+
+This XML will be turned into this one during the parsing:
+
+```xml
+<xml>
+  <response>
+    <original_title>The Irishman</original_title>
+    <main_actor>Robert De Niro</main_actor>
+  </response>
+</xml>
+```
+
+```ruby
+{ movie: { title: "The Irishman", actor: "Robert De Niro" } }
+```
+
 #### array_of
 
 Defines the path to a XML collection, which will be looped generating an array of hashes:

--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ schemas:
     within: info/movie_data
     title: original_title
     actor: main_actor
-
 ```
 ```xml
 <xml>

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ schemas:
 { movie: { title: "The Irishman", actor: "Robert De Niro" } }
 ```
 
-#### unscape
+#### unescape
 
 This option is pretty usefull when you have embbed XML or HTML inside some tag, like CDATA elements, and you need to unescape them first in order to parse their content:
 

--- a/lib/src/extract/hash_builder.rb
+++ b/lib/src/extract/hash_builder.rb
@@ -1,6 +1,6 @@
 module Extract
   class HashBuilder < Base
-    INTERNAL_FIELDS = %i[array_of keep_if within].freeze
+    INTERNAL_FIELDS = %i[array_of keep_if within unescape].freeze
 
     def value(index = 0)
       path, props = node.to_h.values_at(:path, :props)

--- a/lib/src/extract/unescape.rb
+++ b/lib/src/extract/unescape.rb
@@ -1,0 +1,12 @@
+module Extract
+  class Unescape < Base
+    def unescape!
+      unescape_tag = node.props[:unescape]
+
+      paths_to_unescape = extractor.paths_of(node.path, unescape_tag)
+      return if paths_to_unescape.empty?
+
+      paths_to_unescape.each { |path| extractor.unescape!(path) }
+    end
+  end
+end

--- a/lib/src/extract/value_builder.rb
+++ b/lib/src/extract/value_builder.rb
@@ -6,6 +6,7 @@ require_relative "string_value"
 require_relative "value_builder"
 require_relative "within"
 require_relative "expression"
+require_relative "unescape"
 
 module Extract
   class ValueBuilder < Base
@@ -24,6 +25,9 @@ module Extract
 
     def value_for_hash
       props = node.props
+      
+      Unescape.new(node, extractor).unescape! if props[:unescape]
+
       fixed_value = props[:fixed]
       return fixed_value if fixed_value
       return ArrayOf.new(node, extractor).value if props[:array_of]

--- a/spec/complete_example_spec.rb
+++ b/spec/complete_example_spec.rb
@@ -8,8 +8,12 @@ RSpec.describe "Complete Example" do
     <<~XML
       <xml>
         <movies_list>
-          <movie>    
-            <policy>Copyright © 2010 by Wily E. &amp; <br>Coyote All rights reserved.|</br></policy>
+          <movie>
+            <policy>
+              &lt;span style=&quot;font-family: Verdana;&quot; trebuchet=&quot;&quot; ms&quot;;=&quot;&quot; font-size:=&quot;&quot; small;=&quot;&quot; color:=&quot;&quot; rgb(102,=&quot;&quot; 102,=&quot;&quot; 102);&quot;=&quot;&quot;&gt;
+                Copyright &copy; 2010 by Wily E. &amp;amp; &lt;br&gt;Coyote All rights reserved.|&lt;/br&gt;  
+              &lt;/span&gt;
+            </policy>
             <description>The Lord of the Rings: The Fellowship of the Ring</description>
             <total_minutes>209</total_minutes>
             <year>2001</year>

--- a/spec/escaped_spec.rb
+++ b/spec/escaped_spec.rb
@@ -1,0 +1,56 @@
+require "yaml"
+require "json"
+
+RSpec.describe "With nested unescaped xml" do
+  subject { XmlDataExtractor.new(structure).parse(xml) }
+
+  shared_examples_for "match extracted values" do
+    it { expect(JSON.pretty_generate(subject)).to eq JSON.pretty_generate(expected_result) }
+  end
+
+  let(:xml) do
+    <<~XML
+      <xml>
+        <response>&lt;root&gt;&lt;error&gt;&lt;message&gt;Something went wrong&lt;/message&gt;&lt;/error&gt;&lt;/root&gt;</response>
+      </xml>
+    XML
+  end
+
+  let(:yml) do
+    <<~YML
+      schemas:
+        error:
+          unescape: response
+          message: root/error/message
+    YML
+  end
+  let(:structure) { YAML.safe_load(yml).deep_symbolize_keys }
+
+  let(:expected_result) do
+    {
+      error: {
+        message: "Something went wrong",
+      }
+    }
+  end
+
+  include_examples "match extracted values"
+
+  context "when the tag to be unescaped is already a valid XML node" do
+    let(:xml) do
+      <<~XML
+        <xml>
+          <response>
+            <root>
+              <error>
+                <message>Something went wrong</message>
+              </error>
+            </root>
+          </response>
+        </xml>
+      XML
+    end
+
+    include_examples "match extracted values"
+  end
+end

--- a/spec/unescape_spec.rb
+++ b/spec/unescape_spec.rb
@@ -1,0 +1,58 @@
+require "yaml"
+require "json"
+
+RSpec.describe "Unescape" do
+  subject { XmlDataExtractor.new(structure).parse(xml) }
+
+  context "when the XML contains embedded escaped XML content" do
+    shared_examples_for "match extracted values" do
+      it { expect(JSON.pretty_generate(subject)).to eq JSON.pretty_generate(expected_result) }
+    end
+  
+    let(:xml) do
+      <<~XML
+        <xml>
+          <response>&lt;root&gt;&lt;error&gt;&lt;message&gt;Something went wrong&lt;/message&gt;&lt;/error&gt;&lt;/root&gt;</response>
+        </xml>
+      XML
+    end
+  
+    let(:yml) do
+      <<~YML
+        schemas:
+          error:
+            unescape: response
+            message: root/error/message
+      YML
+    end
+    let(:structure) { YAML.safe_load(yml).deep_symbolize_keys }
+  
+    let(:expected_result) do
+      {
+        error: {
+          message: "Something went wrong",
+        }
+      }
+    end
+  
+    include_examples "match extracted values"
+  
+    context "when the tag to be unescaped is already a valid XML node" do
+      let(:xml) do
+        <<~XML
+          <xml>
+            <response>
+              <root>
+                <error>
+                  <message>Something went wrong</message>
+                </error>
+              </root>
+            </response>
+          </xml>
+        XML
+      end
+  
+      include_examples "match extracted values"
+    end
+  end
+end

--- a/xml_data_extractor.gemspec
+++ b/xml_data_extractor.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "xml_data_extractor"
-  spec.version       = "0.3.0"
+  spec.version       = "0.4.0"
   spec.authors       = ["Fernando Almeida"]
   spec.email         = ["fernandoprsbr@gmail.com"]
 


### PR DESCRIPTION
Currently, we are doing a full unescape on the XML before parsing it. But it is not a safe approach, some times you are going the find some XML's which have invalid content inside unescaped tags.

If we do the full document unescaping in this case, we are going to break the Nokogiri xpath navigation, because the invalid tags will be part of the tree, even if that tag is not being extracted.

Therefore, I removed the full unescape and added an option to just unescape the specific tags if you really need to. If there are some invalid content inside some unescaped tag content, Nokogiri can proceed with the parsing because this content will be treated as plain text content.