### PR TITLE
Corrige carregamento do ActiveSupport 

### DIFF
--- a/lib/src/extractor.rb
+++ b/lib/src/extractor.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "cgi"
-require "active_support/core_ext/string"
+require "active_support"
+require "active_support/core_ext"
 require_relative "format/formatter"
 
 class PathBuilder < Struct.new(:base, :parent, :tag, keyword_init: true)


### PR DESCRIPTION
Conforme [comentado nessa issue](https://github.com/CocoaPods/CocoaPods/issues/12089#issuecomment-1768713084), o ActiveSupport 7.1 mudou sua API e agora carrega apenas as dependências mínimas. 
Foi preciso adicionar o  `require "active_support"` e o `require "active_support/core_ext"` para o "extractor" funcionar.