### PR TITLE
Adiciona configuração no workflow do GitHub para mostrar o link do PR no commit 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,17 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Merge pull request
-        uses: pascalgn/automerge-action@v0.16.4
+        run: |
+          PR_NUMBER=$(basename "$PR_URL")
+          PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q ".title")
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q ".body")
+          COMMIT_MESSAGE="${PR_TITLE} (#${PR_NUMBER})"
+
+          gh pr merge "$PR_URL" --auto --squash --subject "$COMMIT_MESSAGE" --body "$PR_BODY"
         env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGE_LABELS: "automerge"
-          MERGE_METHOD: "squash"
-          MERGE_COMMIT_MESSAGE: |
-            ${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})
-            ${{ github.event.pull_request.body }}
-          MERGE_DELETE_BRANCH: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_LABELS: "automerge"
           MERGE_METHOD: "squash"
-          MERGE_COMMIT_MESSAGE: "pull-request-title-and-description"
+          MERGE_COMMIT_MESSAGE: |
+            {pullRequest.title} (#{pullRequest.number})
+            {pullRequest.commitDetails}
           MERGE_DELETE_BRANCH: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: ci
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  push:
+    branches: [master]
 
 jobs:
   qa:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,6 @@ jobs:
           MERGE_LABELS: "automerge"
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: |
-            {pullRequest.title} (#{pullRequest.number})
-            {pullRequest.commitDetails}
+            ${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})
+            ${{ github.event.pull_request.body }}
           MERGE_DELETE_BRANCH: "true"


### PR DESCRIPTION
issue [Configurar automerge dos PRs sem utilizar kodiak](https://github.com/monde-sistemas/melhorias/issues/349)

No commit, estava mostrando apenas o título e os detalhes do PR. Não tinha o link do PR. Estou adicionando essa configuração para mostrar o link do PR no commit.
Também estou alterando a forma de fazer o merge, removendo o pascalgn/automerge-action porque ele estava [falhando em alguns PRs](https://github.com/monde-sistemas/m2/actions/runs/12121505151/job/33793229889). Encontrei https://github.com/pascalgn/automerge-action/issues/122 sobre o problema.